### PR TITLE
Only validate modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ jobs:
           readme_enabled: true
 
     outputs:
-      result: ${{ steps.readme.outputs.result1 }}
+      banner_file: ${{ steps.readme.outputs.banner_file }}
+      readme_file: ${{ steps.readme.outputs.readme_file }}
 ```
 
 ## Advanced Usage
@@ -137,18 +138,18 @@ it to the main branch.
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| banner\_enabled | banner\_enabled | true | false |
+| banner\_enabled | Enable banner generation | true | false |
 | commit\_author | The author to use when committing changes. | readme-action 📖 <actions@github.com> | false |
-| commit\_message | The commit message to use when committing changes. | chore: update README.md and docs | false |
+| commit\_message | The commit message to use when committing changes. | chore: update README.md | false |
 | commit\_method | The method to apply changes. Can be either 'commit' or 'pr'. | commit | true |
 | commit\_user\_email | The user email to use when committing changes. | actions@github.com | false |
 | commit\_user\_name | The user name to use when committing changes. | readme-action 📖 | false |
 | pr\_base\_branch | Repo default base-branch for Pull Requests (when commit\_method: pr) |  | false |
 | pr\_labels | Whitespace-separated list of labels to apply to Pull Requests (when commit\_method: pr) | auto-update<br>no-release<br>readme<br> | false |
 | pr\_title | The title to use when creating a Pull Request (when commit\_method: pr) | Update README.md and docs | false |
-| readme\_enabled | readme\_enabled | true | false |
-| repository\_description | repository\_description |  | false |
-| repository\_name | repository\_name |  | false |
+| readme\_enabled | Enable README generation | true | false |
+| repository\_description | GitHub repository description |  | false |
+| repository\_name | GitHub repository name in the `repository\_org` that hosts the banner templates |  | false |
 | repository\_org | GitHub organization or user name used for the banner templates |  | false |
 | token | GitHub API token (use a PAT if you need to trigger other actions) | ${{ github.token }} | false |
 | validate\_readme | Validate the README.md file using markdown-link-check | true | false |

--- a/README.yaml
+++ b/README.yaml
@@ -71,7 +71,8 @@ usage: |-
             readme_enabled: true
 
       outputs:
-        result: ${{ steps.readme.outputs.result1 }}
+        banner_file: ${{ steps.readme.outputs.banner_file }}
+        readme_file: ${{ steps.readme.outputs.readme_file }}
   ```
 
   ## Advanced Usage

--- a/action.yml
+++ b/action.yml
@@ -218,6 +218,7 @@ runs:
       if: inputs.readme_enabled == 'true' && inputs.validate_readme == 'true'
       with:
         file-path: ${{ steps.readme.outputs.file }}
+        check-modified-files-only: true
 
     - uses: stefanzweifel/git-auto-commit-action@v4
       if: inputs.commit_method == 'commit'

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -4,18 +4,18 @@
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| banner\_enabled | banner\_enabled | true | false |
+| banner\_enabled | Enable banner generation | true | false |
 | commit\_author | The author to use when committing changes. | readme-action 📖 <actions@github.com> | false |
-| commit\_message | The commit message to use when committing changes. | chore: update README.md and docs | false |
+| commit\_message | The commit message to use when committing changes. | chore: update README.md | false |
 | commit\_method | The method to apply changes. Can be either 'commit' or 'pr'. | commit | true |
 | commit\_user\_email | The user email to use when committing changes. | actions@github.com | false |
 | commit\_user\_name | The user name to use when committing changes. | readme-action 📖 | false |
 | pr\_base\_branch | Repo default base-branch for Pull Requests (when commit\_method: pr) |  | false |
 | pr\_labels | Whitespace-separated list of labels to apply to Pull Requests (when commit\_method: pr) | auto-update<br>no-release<br>readme<br> | false |
 | pr\_title | The title to use when creating a Pull Request (when commit\_method: pr) | Update README.md and docs | false |
-| readme\_enabled | readme\_enabled | true | false |
-| repository\_description | repository\_description |  | false |
-| repository\_name | repository\_name |  | false |
+| readme\_enabled | Enable README generation | true | false |
+| repository\_description | GitHub repository description |  | false |
+| repository\_name | GitHub repository name in the `repository\_org` that hosts the banner templates |  | false |
 | repository\_org | GitHub organization or user name used for the banner templates |  | false |
 | token | GitHub API token (use a PAT if you need to trigger other actions) | ${{ github.token }} | false |
 | validate\_readme | Validate the README.md file using markdown-link-check | true | false |


### PR DESCRIPTION
## what
- attempt to only validate files modified
- fix usage example

## why
- by default, it seems to want search all files in the directory, not just those specified by the `file-path` input. This causes it to hit 429 rate limit issues. 
- Validating files not modified should not be in scope