### PR TITLE
set max-depth to 0 for link checker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -219,6 +219,7 @@ runs:
       with:
         file-path: ${{ steps.readme.outputs.file }}
         check-modified-files-only: true
+        max-depth: 0
 
     - uses: stefanzweifel/git-auto-commit-action@v4
       if: inputs.commit_method == 'commit'


### PR DESCRIPTION
## what
* Set `max-depth` to `0`

## why
* It's not respecting checking only modified files and it's recursing deep into all folders. Not sure what else to try.