### PR TITLE
Use atmos to generate readme

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -113,6 +113,37 @@ usage: |-
               banner_enabled: true
               readme_enabled: true
   ```
+
+  ### Migrating from `v0` to `v1`
+  
+  `v1` use [atmos](https://atmos.tools/cli/commands/docs/generate) instead of [build-harness](https://github.com/cloudposse/build-harness).
+  You can drop `Makefile` if you use it only for readme generation.
+  To support atmos reaadme generation, you must create `atmos.yaml` config. 
+  The configuration depends on your repo - please follow this [documentation](https://atmos.tools/cli/commands/docs/generate)
+
+  Example: 
+
+  ```yaml filename="atmos.yaml"
+  docs:
+  generate:
+    readme:
+      base-dir: .
+      input:
+        - "./README.yaml"
+      template: "https://.../README.md.gotmpl"
+      output: "./README.md"
+      terraform:
+        source: src/
+        enabled: false
+        format: "markdown"
+        show_providers: false
+        show_inputs: true
+        show_outputs: true
+        sort_by: "name"
+        hide_empty: false
+        indent_level: 2
+  ```
+  
 include:
   - "docs/github-action.md"
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ inputs:
   target:
     description: "Configuration name"
     required: true
+    default: 'readme'
 
   validate_readme:
     required: false
@@ -224,7 +225,7 @@ runs:
       env:
         GITHUB_TOKEN: "${{ inputs.token }}"
       run: |
-        output_file=$(atmos docs generate readme 2>&1 | sed -n -e  "s/^.*output=//p")
+        output_file=$(atmos docs generate ${{ inputs.target }} 2>&1 | sed -n -e  "s/^.*output=//p")
         # Get relative path from absolute
         output_file=$(realpath -s --relative-to="$PWD" "$output_file")
         # Ignore changes if they are only whitespace

--- a/action.yml
+++ b/action.yml
@@ -97,13 +97,6 @@ inputs:
     required: false
     default: '>= 1.175.0'
 
-  token:
-    description:
-      Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically
-      not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
-      GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
-    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
-
 outputs:
   banner_file:
     description: "Generated banner file path (if banner_enabled: true)"

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.175.0"
+    default: '>= 1.175.0'
 
   token:
     description: |-

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,18 @@ inputs:
       no-release
       readme
 
+  atmos-version:
+    description: The version of atmos to install
+    required: false
+    default: ">= 1.175.0"
+
+  token:
+    description:
+      Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically
+      not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
+      GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+
 outputs:
   banner_file:
     description: "Generated banner file path (if banner_enabled: true)"
@@ -201,14 +213,12 @@ runs:
         viewportHeight: 320
         omitBackground: true
 
-    - name: Initialize Makefile with `build-harness` support
-      if: inputs.readme_enabled == 'true'
-      shell: bash
-      run: |
-        if [[ ! -f Makefile ]]; then
-          echo '-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)' > Makefile
-        fi
-        make init
+    - name: Install Atmos
+      uses: cloudposse/github-action-setup-atmos@v2
+      with:
+        atmos-version: ${{ inputs.atmos-version }}
+        token: ${{ inputs.token }}
+        install-wrapper: false
 
     - name: Update readme
       if: inputs.readme_enabled == 'true'
@@ -217,7 +227,7 @@ runs:
       env:
         GITHUB_TOKEN: "${{ inputs.token }}"
       run: |
-        make readme/build
+        atmos docs generate readme
         # Ignore changes if they are only whitespace
         if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
           git restore README.md

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ inputs:
     default: '>= 1.175.0'
 
   token:
-    description: |-
+    description:
       Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     required: false
     default: 'true'
 
+  target:
+    description: "Configuration name"
+    required: true
+
   validate_readme:
     required: false
     default: 'true'
@@ -220,13 +224,15 @@ runs:
       env:
         GITHUB_TOKEN: "${{ inputs.token }}"
       run: |
-        atmos docs generate readme
+        output_file=$(atmos docs generate readme 2>&1 | sed -n -e  "s/^.*output=//p")
+        # Get relative path from absolute
+        output_file=$(realpath -s --relative-to="$PWD" "$output_file")
         # Ignore changes if they are only whitespace
-        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
-          git restore README.md
-          echo Ignoring whitespace-only changes in README
+        if ! git diff --quiet ${output_file} && git diff --ignore-all-space --ignore-blank-lines --quiet ${output_file}; then
+          git restore ${output_file}
+          echo Ignoring whitespace-only changes in generated file
         fi
-        echo "file=README.md" >> $GITHUB_OUTPUT
+        echo "file=${output_file}" >> $GITHUB_OUTPUT
 
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       if: inputs.readme_enabled == 'true' && inputs.validate_readme == 'true'

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ inputs:
     default: ">= 1.175.0"
 
   token:
-    description:
+    description: |-
       Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.


### PR DESCRIPTION
## what
* Use atmos to generate readme

## why
* Build-harness is depricated


### Migrating from `v0` to `v1`
  
  `v1` use [atmos](https://atmos.tools/cli/commands/docs/generate) instead of [build-harness](https://github.com/cloudposse/build-harness).
  You can drop `Makefile` if you use it only for readme generation.
  To support atmos reaadme generation, you must create `atmos.yaml` config. 
  The configuration depends on your repo - please follow this [documentation](https://atmos.tools/cli/commands/docs/generate)
  Example: 
  ```yaml filename="atmos.yaml"
  docs:
    generate:
      readme:
        base-dir: .
        input:
          - "./README.yaml"
        template: "https://.../README.md.gotmpl"
        output: "./README.md"
        terraform:
          source: src/
          enabled: false
          format: "markdown"
          show_providers: false
          show_inputs: true
          show_outputs: true
          sort_by: "name"
          hide_empty: false
          indent_level: 2
  ```